### PR TITLE
Add link check action

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,5 +1,5 @@
-# Workflow for building and link checking a Hugo site on PRs
-name: Build and Link Check Hugo site on PRs
+# Workflow for link checking with lychee
+name: Link Check Source Files with Lychee
 
 on:
   # Runs on pull requests targeting the dev branch
@@ -8,45 +8,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Default to bash
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  # Build and Link Check job
-  build_and_link_check:
+  link_check:
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.128.0
     steps:
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
-
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
-
-      - name: Build with Hugo
-        env:
-          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
-          HUGO_ENVIRONMENT: production
-        run: hugo --minify
-
-      - name: List files in the public directory with the HUGO build
-        run: ls -R public
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --exclude "https://neurodatawithoutborders.github.io/" 'public/**/*.html'
+          args: --verbose --no-progress --exclude "https://example.com" './**/*.md' './**/*.html' './**/*.rst'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,11 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update CA certificates
-        run: sudo update-ca-certificates
-
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst'
+          # NOTE: Lychee (and sphinx) encounter issues with SSL certificates for INCF URLs, so use --insecure
+          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst' --insecure

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,11 +1,11 @@
-# Workflow for building and link checking the Hugo site on PRs
-name: Build and Link Check
+# Workflow for building and link checking a Hugo site on PRs
+name: Build and Link Check Hugo site on PRs
 
 on:
   # Runs on pull requests targeting the dev branch
   pull_request:
     branches: ["dev"]
-  # Allows running this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # Default to bash
@@ -40,12 +40,13 @@ jobs:
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           HUGO_ENVIRONMENT: production
-        run: |
-          hugo --minify
+        run: hugo --minify
+
+      - name: List files in public directory
+        run: ls -R public
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          fail: false
           args: --verbose --exclude "https://example.com" public

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,54 @@
+# Workflow for building and link checking the Hugo site on PRs
+name: Build and Link Check
+
+on:
+  # Runs on pull requests targeting the dev branch
+  pull_request:
+    branches: ["dev"]
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build and Link Check job
+  build_and_link_check:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.128.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo --minify
+
+      - name: Install lychee
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
+          curl -sSfL https://raw.githubusercontent.com/lycheeverse/lychee/main/install.sh | bash
+
+      - name: Run lychee
+        run: |
+          ./lychee --verbose --exclude "https://example.com" public

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --exclude "https://example.com" './**/*.md' './**/*.html' './**/*.rst'
+          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -42,11 +42,11 @@ jobs:
           HUGO_ENVIRONMENT: production
         run: hugo --minify
 
-      - name: List files in public directory
+      - name: List files in the public directory with the HUGO build
         run: ls -R public
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --exclude "https://example.com" public
+          args: --verbose --no-progress 'public/**/*.html'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Update CA certificates
+        run: sudo update-ca-certificates
+
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst' --insecure
+          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst' --user-agent "curl/8.4.0"
+          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst' --insecure

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -49,4 +49,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress 'public/**/*.html'
+          args: --verbose --no-progress --exclude "https://neurodatawithoutborders.github.io/" 'public/**/*.html'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,12 +43,9 @@ jobs:
         run: |
           hugo --minify
 
-      - name: Install lychee
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl
-          curl -sSfL https://raw.githubusercontent.com/lycheeverse/lychee/main/install.sh | bash
-
-      - name: Run lychee
-        run: |
-          ./lychee --verbose --exclude "https://example.com" public
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+          args: --verbose --exclude "https://example.com" public

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst'
+          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst' --user-agent "curl/8.4.0"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /public/**
 .hugo_build.lock
 /todo.md
+
+# PyCharm
+.idea/


### PR DESCRIPTION
Add GitHub action to run a link checker on the source files

This action does not build the website but checks links only in the source files directly. If we want to check all links, we should also add action to deploy the PRs to a temporary place so that we can run the linkchecker on that. 