### PR TITLE
Update workshop and showcase event pages

### DIFF
--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -1,0 +1,40 @@
+## Code of Conduct
+
+We are dedicated to providing a harassment-free event experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue, including talks. event participants violating these rules may be sanctioned or expelled from the event without a refund at the discretion of the event organizers.
+
+Harassment includes, but is not limited to:
+
+- Verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion.
+- Sexual images in public spaces
+- Deliberate intimidation, stalking, or following
+- Harassing photography or recording
+- Sustained disruption of talks or other events
+- Inappropriate physical contact
+- Unwelcome sexual attention
+- Advocating for, or encouraging, any of the above behaviour
+
+### Enforcement
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Organizers and presenters are also subject to the anti-harassment policy. In particular, they should not use sexualized images, activities, or other material.
+
+Event organisers may take action to redress anything designed to, or with the clear impact of, disrupting the event or making the environment hostile for any participants.
+
+If a participant engages in harassing behaviour, event organisers have the responsibility to remind the offender about our Code of Conduct, and warn them that repeated inappropriate, uncivil, threatening, offensive, or harmful behavior can lead to a temporary or permanent ban from the event with no refund. The offending person(s) may also see affected their participation in future NWB and DANDI events.
+
+We expect participants to follow these rules at all event venues and event-related social activities. We think people should follow these rules outside event activities too!
+
+### Reporting
+
+If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to the events organizers. Harassment and other code of conduct violations reduce the value of our event for everyone. We want you to be happy at our event. People like you make our event a better place.
+
+You can make a report either with your personal email or using an anonymous email.
+
+### NWB Contributor Code of Conduct
+
+When directly contributing to the NWB project, contributors are expected to follow the [NWB Contributor Code of Conduct](/code_of_conduct/)
+
+### Credit
+
+This hackathon code of conduct is adapted from the [Brainhack Code of Conduct](https://brainhack.org/code-of-conduct.html).

--- a/content/events/hck22-2025-dataconversion-remote.md
+++ b/content/events/hck22-2025-dataconversion-remote.md
@@ -1,7 +1,7 @@
 ---
 title: "NWB Data Conversion Workshop 2025"
 date: 2025-05-12
-endDate: 2025-05-14
+endDate: 2025-05-13
 location: "Virtual"
 eventType: "Workshop"
 image: "/images/events/hck22-2025-dataconversion-remote/logo_brain_text_white_hor.png"
@@ -52,7 +52,143 @@ We will be using Gather and Zoom for the meeting and will send an email in the d
 
 ## Agenda
 
-The agenda will be shared at a later date.
+All times are in Pacific Time (PT, UTC-7). 
+
+### Day 1 (Monday, May 12)
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th style="width: 10%">Time</th>
+      <th style="width: 10%">Duration</th>
+      <th style="width: 35%">Topic</th>
+      <th style="width: 15%">Speaker(s)</th>
+      <th style="width: 10%">Location</th>
+      <th style="width: 15%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>9:00 - 9:15 AM</td>
+      <td>15 min</td>
+      <td>Welcome to the Data Conversion Workshop</td>
+      <td>Steph Prince</td>
+      <td>Gather</td>
+      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
+    </tr>
+    <tr>
+      <td>9:15 - 10:00 AM</td>
+      <td>45 min</td>
+      <td>Overview of NWB</td>
+      <td>Oliver Ruebel</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
+    </tr>
+    <tr>
+      <td>10:00 - 10:45 AM</td>
+      <td>45 min</td>
+      <td>NWB GUIDE</td>
+      <td>Ryan Ly</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
+    </tr>
+    <tr>
+      <td>10:45 - 11:45 AM</td>
+      <td>1 hour</td>
+      <td>NeuroConv, PyNWB, MatNWB</td>
+      <td>Ben Dichter</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
+    </tr>
+    <tr>
+      <td>11:45 AM - 12:15 PM</td>
+      <td>30 min</td>
+      <td>Project sharing</td>
+      <td>Steph Prince</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
+    </tr>
+    <tr>
+      <td>12:15 - 5:00 PM</td>
+      <td>4.75 hours</td>
+      <td>Data conversion hacking</td>
+      <td></td>
+      <td>Gather</td>
+      <td><kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px;">Hack</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### Day 2 (Tuesday, May 13)
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th style="width: 10%">Time</th>
+      <th style="width: 10%">Duration</th>
+      <th style="width: 35%">Topic</th>
+      <th style="width: 15%">Speaker(s)</th>
+      <th style="width: 10%">Location</th>
+      <th style="width: 15%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>9:00 - 9:10 AM</td>
+      <td>10 min</td>
+      <td>Welcome to the workshop</td>
+      <td>Steph Prince, Oliver Ruebel</td>
+      <td>Gather</td>
+      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
+    </tr>
+    <tr>
+      <td>9:10 - 10:40 AM</td>
+      <td>1.5 hours</td>
+      <td>Tools and data showcase</td>
+      <td>Alessandra Trapani, Steph Prince</td>
+      <td>Gather</td>
+      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
+    </tr>
+    <tr>
+      <td>10:45 - 11:15 AM</td>
+      <td>30 min</td>
+      <td>Extensions and TAB discussion</td>
+      <td>Alessio Buccino, Yaroslav Halchenko</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
+    </tr>
+    <tr>
+      <td>11:15 AM - 12:00 PM</td>
+      <td>45 min</td>
+      <td>Publishing data and using the DANDI Archive</td>
+      <td>Ben Dichter</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
+    </tr>
+    <tr>
+      <td>12:00 - 12:45 PM</td>
+      <td>45 min</td>
+      <td>How to organize community NWB events</td>
+      <td>Steph Prince</td>
+      <td>Zoom</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
+    </tr>
+    <tr>
+      <td>12:45 - 4:00 PM</td>
+      <td>3.25 hours</td>
+      <td>Data conversion hacking</td>
+      <td></td>
+      <td>Gather</td>
+      <td><kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px;">Hack</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### Legend
+<kbd style="background-color:#F75C81; color: white; border-radius: 4px; padding: 3px 6px; margin: 0 3px;">Talk</kbd> Presentation sessions  
+<kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px; margin: 0 3px;">Hack</kbd> Hands-on coding sessions  
+<kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px; margin: 0 3px;">Tutorial</kbd> Tutorials with hacking exercises  
+<kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px; margin: 0 3px;">Discussion</kbd> Group conversations and networking
 
 ## Code of Conduct
 

--- a/content/events/hck22-2025-dataconversion-remote.md
+++ b/content/events/hck22-2025-dataconversion-remote.md
@@ -15,13 +15,13 @@ registration: "Register for the event [here](https://forms.gle/5Sewge3qpozxnrATA
 resources:
   "NWB GUIDE": "https://nwb-guide.readthedocs.io/en/latest/installation.html"
   "PyNWB (Python)": "https://pynwb.readthedocs.io/en/stable/install_users.html"
-  "MatNWB (Matlab)": "https://neurodatawithoutborders.github.io/matnwb/"
+  "MatNWB (Matlab)": "https://matnwb.readthedocs.io/en/latest/pages/getting_started/installation_users.html"
   "NWB Overview Docs": "https://nwb-overview.readthedocs.io"
 ---
 
 ## Objective
 
-The [Neurodata Without Borders](nwb.org) project is an effort to standardize the description and storage of neurophysiology
+The [Neurodata Without Borders](http://nwb.org) project is an effort to standardize the description and storage of neurophysiology
 data and metadata. NWB enables data sharing and reuse and reduces the energy barrier to applying data analytics both within
 and across labs. NWB has seen wide adoption in the neurophysiology community, and there are now over 100 datasets on the
 DANDI Archive in NWB, including data from the Allen Institute and the International Brain Laboratory.
@@ -45,14 +45,14 @@ We will be using Gather and Zoom for the meeting and will send an email in the d
 * Bring your laptop with appropriate software installed. For installation instructions see:
   * [**NWB GUIDE**](https://nwb-guide.readthedocs.io/en/latest/installation.html)
   * [**PyNWB (Python)**](https://pynwb.readthedocs.io/en/stable/install_users.html)
-  * [**MatNWB (Matlab)**](https://neurodatawithoutborders.github.io/matnwb/)
+  * [**MatNWB (Matlab)**](https://matnwb.readthedocs.io/en/latest/pages/getting_started/installation_users.html)
 * For an overview of NWB software, see also: 
   * [**Glossary of Core NWB Tools**](https://nwb-overview.readthedocs.io/en/latest/core_tools/core_tools_home.html) 
   * [**Glossary of Analysis and Visualization Tools**](https://nwb-overview.readthedocs.io/en/latest/tools/analysis_tools_home.html)
 
 ## Agenda
 
-All times are in Pacific Time (PT, UTC-7). 
+Below is the tentative agenda. All times are in Pacific Time (PT, UTC-7). 
 
 ### Day 1 (Monday, May 12)
 
@@ -62,9 +62,9 @@ All times are in Pacific Time (PT, UTC-7).
       <th style="width: 10%">Time</th>
       <th style="width: 10%">Duration</th>
       <th style="width: 35%">Topic</th>
-      <th style="width: 15%">Speaker(s)</th>
-      <th style="width: 10%">Location</th>
       <th style="width: 15%">Type</th>
+      <th style="width: 15%">Speaker(s)</th>
+      <th style="width: 15%">Location</th>
     </tr>
   </thead>
   <tbody>
@@ -72,49 +72,49 @@ All times are in Pacific Time (PT, UTC-7).
       <td>9:00 - 9:15 AM</td>
       <td>15 min</td>
       <td>Welcome to the Data Conversion Workshop</td>
+      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
       <td>Steph Prince</td>
       <td>Gather</td>
-      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
     </tr>
     <tr>
       <td>9:15 - 10:00 AM</td>
       <td>45 min</td>
       <td>Overview of NWB</td>
+      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
       <td>Oliver Ruebel</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
     </tr>
     <tr>
       <td>10:00 - 10:45 AM</td>
       <td>45 min</td>
       <td>NWB GUIDE</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
       <td>Ryan Ly</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
     </tr>
     <tr>
       <td>10:45 - 11:45 AM</td>
       <td>1 hour</td>
       <td>NeuroConv, PyNWB, MatNWB</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
       <td>Ben Dichter</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
     </tr>
     <tr>
       <td>11:45 AM - 12:15 PM</td>
       <td>30 min</td>
       <td>Project sharing</td>
+      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
       <td>Steph Prince</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
     </tr>
     <tr>
       <td>12:15 - 5:00 PM</td>
       <td>4.75 hours</td>
       <td>Data conversion hacking</td>
+      <td><kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px;">Hack</kbd></td>
       <td></td>
       <td>Gather</td>
-      <td><kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px;">Hack</kbd></td>
     </tr>
   </tbody>
 </table>
@@ -127,9 +127,9 @@ All times are in Pacific Time (PT, UTC-7).
       <th style="width: 10%">Time</th>
       <th style="width: 10%">Duration</th>
       <th style="width: 35%">Topic</th>
-      <th style="width: 15%">Speaker(s)</th>
-      <th style="width: 10%">Location</th>
       <th style="width: 15%">Type</th>
+      <th style="width: 15%">Speaker(s)</th>
+      <th style="width: 15%">Location</th>
     </tr>
   </thead>
   <tbody>
@@ -137,49 +137,49 @@ All times are in Pacific Time (PT, UTC-7).
       <td>9:00 - 9:10 AM</td>
       <td>10 min</td>
       <td>Welcome to the workshop</td>
+      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
       <td>Steph Prince, Oliver Ruebel</td>
       <td>Gather</td>
-      <td><kbd style="background-color: #F75C81; color: white; border-radius: 4px; padding: 3px 6px;">Talk</kbd></td>
     </tr>
     <tr>
       <td>9:10 - 10:40 AM</td>
       <td>1.5 hours</td>
       <td>Tools and data showcase</td>
+      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
       <td>Alessandra Trapani, Steph Prince</td>
       <td>Gather</td>
-      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
     </tr>
     <tr>
       <td>10:45 - 11:15 AM</td>
       <td>30 min</td>
       <td>Extensions and TAB discussion</td>
+      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
       <td>Alessio Buccino, Yaroslav Halchenko</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #8974D6; color: white; border-radius: 4px; padding: 3px 6px;">Discussion</kbd></td>
     </tr>
     <tr>
       <td>11:15 AM - 12:00 PM</td>
       <td>45 min</td>
       <td>Publishing data and using the DANDI Archive</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
       <td>Ben Dichter</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
     </tr>
     <tr>
       <td>12:00 - 12:45 PM</td>
       <td>45 min</td>
       <td>How to organize community NWB events</td>
+      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
       <td>Steph Prince</td>
       <td>Zoom</td>
-      <td><kbd style="background-color: #64C0FF; color: white; border-radius: 4px; padding: 3px 6px;">Tutorial</kbd></td>
     </tr>
     <tr>
       <td>12:45 - 4:00 PM</td>
       <td>3.25 hours</td>
       <td>Data conversion hacking</td>
+      <td><kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px;">Hack</kbd></td>
       <td></td>
       <td>Gather</td>
-      <td><kbd style="background-color: #59D382; color: white; border-radius: 4px; padding: 3px 6px;">Hack</kbd></td>
     </tr>
   </tbody>
 </table>
@@ -192,4 +192,4 @@ All times are in Pacific Time (PT, UTC-7).
 
 ## Code of Conduct
 
-Please see the [Code of Conduct](https://neurodatawithoutborders.github.io/nwb_hackathons/code_of_conduct) for all NWB events.
+Please see the [Code of Conduct](/code_of_conduct) for all NWB events.

--- a/content/events/hck22-2025-dataconversion-remote.md
+++ b/content/events/hck22-2025-dataconversion-remote.md
@@ -21,7 +21,7 @@ resources:
 
 ## Objective
 
-The [Neurodata Without Borders](http://nwb.org) project is an effort to standardize the description and storage of neurophysiology
+The [Neurodata Without Borders](https://nwb.org) project is an effort to standardize the description and storage of neurophysiology
 data and metadata. NWB enables data sharing and reuse and reduces the energy barrier to applying data analytics both within
 and across labs. NWB has seen wide adoption in the neurophysiology community, and there are now over 100 datasets on the
 DANDI Archive in NWB, including data from the Allen Institute and the International Brain Laboratory.

--- a/content/events/hck23-2025-openneurodata-showcase.md
+++ b/content/events/hck23-2025-openneurodata-showcase.md
@@ -18,7 +18,7 @@ registration: "Register as an attendee [here](https://forms.gle/rj8gYB92guBMcQZN
 resources:
   "Event Page": "https://neurodatawithoutborders.github.io/nwb_hackathons/HCK23_2025_OpenNeurodataShowcase/"
   "DANDI Archive": "https://dandiarchive.org"
-  "Data Conversion Workshop": "https://neurodatawithoutborders.github.io/nwb_hackathons/HCK22_2025_DataConversion_Remote/"
+  "Data Conversion Workshop": "/events/hck22-2025-dataconversion-remote.md"
 ---
 
 ## Dates and Location
@@ -96,7 +96,7 @@ This virtual event is open to anyone interested in neurophysiology data and tool
 
 ## Related Events
 
-The Neurodata and Tools Showcase is also part of a multi-day NWB Data Conversion workshop. If you are interested in attending these additional sessions to learn more about converting your own data to NWB and publishing on DANDI, please see the [Data Conversion Workshop page](https://neurodatawithoutborders.github.io/nwb_hackathons/HCK22_2025_DataConversion_Remote/) for more details.
+The Neurodata and Tools Showcase is also part of a multi-day NWB Data Conversion workshop. If you are interested in attending these additional sessions to learn more about converting your own data to NWB and publishing on DANDI, please see the [Data Conversion Workshop page](/events/hck22-2025-dataconversion-remote.md) for more details.
 
 ## Organizing Committee
 
@@ -108,4 +108,4 @@ The Neurodata and Tools Showcase is also part of a multi-day NWB Data Conversion
 
 ## Code of Conduct
 
-Please see the [Code of Conduct](https://neurodatawithoutborders.github.io/nwb_hackathons/code_of_conduct) for all NWB events.
+Please see the [Code of Conduct](/code_of_conduct) for all NWB events.

--- a/content/events/hck23-2025-openneurodata-showcase.md
+++ b/content/events/hck23-2025-openneurodata-showcase.md
@@ -18,7 +18,7 @@ registration: "Register as an attendee [here](https://forms.gle/rj8gYB92guBMcQZN
 resources:
   "Event Page": "https://neurodatawithoutborders.github.io/nwb_hackathons/HCK23_2025_OpenNeurodataShowcase/"
   "DANDI Archive": "https://dandiarchive.org"
-  "Data Conversion Workshop": "/events/hck22-2025-dataconversion-remote.md"
+  "Data Conversion Workshop": "/events/hck22-2025-dataconversion-remote/"
 ---
 
 ## Dates and Location
@@ -96,7 +96,7 @@ This virtual event is open to anyone interested in neurophysiology data and tool
 
 ## Related Events
 
-The Neurodata and Tools Showcase is also part of a multi-day NWB Data Conversion workshop. If you are interested in attending these additional sessions to learn more about converting your own data to NWB and publishing on DANDI, please see the [Data Conversion Workshop page](/events/hck22-2025-dataconversion-remote.md) for more details.
+The Neurodata and Tools Showcase is also part of a multi-day NWB Data Conversion workshop. If you are interested in attending these additional sessions to learn more about converting your own data to NWB and publishing on DANDI, please see the [Data Conversion Workshop page](/events/hck22-2025-dataconversion-remote/) for more details.
 
 ## Organizing Committee
 

--- a/content/events/hck23-2025-openneurodata-showcase.md
+++ b/content/events/hck23-2025-openneurodata-showcase.md
@@ -77,6 +77,23 @@ This virtual event is open to anyone interested in neurophysiology data and tool
 - If you are interested in **attending** the event, register using the attendee registration link above.
 - If you are interested in **presenting** a dandiset or tool, register as a presenter using the presenter registration link above.
 
+## Presenters
+
+- Spyglass: a NWB-based framework for reproducible and shareable neuroscience research. *Eric Denovellis*.
+- Reading and writing NWB files with the Open Ephys GUI. *Anjal Doshi*.
+- CEBRA: a self-supervised learning algorithm for obtaining interpretable, Consistent EmBeddings of high-dimensional Recordings using Auxiliary variables. *Steffen Schneider*.
+- ElecFeX: a user-friendly toolbox for efficient feature extraction from single-cell electrophysiological recordings. *Xinyue Ma*.
+- ROICaT: Region of Interest Classification and Tracking. *Richard Hakim*, *David Feng*.
+- Multichannel Igor Electrophysiology Suite (MIES). *Thomas Braun*.
+- Pynapple and NeMoS: Standardizing Systems Neuroscience Analyses with Open Source Software. *Sarah Jo Venditto*.
+- Neo: a python package for working with electrophysiology data. *Andrew Davison*, *Zach McKenzie*.
+- Visualizing and analyzing DANDI datasets with NWB Explorer and Open Source Brain. *Padraig Gleeson*.
+- AqNWB: enabling acquisition of neurophysiology data in NWB. *Steph Prince*, *Oliver Ruebel*.
+- GuPPy: a Python toolbox for the analysis of fiber photometry data. *Venus N Sherathiya*.
+- Esr1+ hypothalamic-habenula neurons shape aversive states (DANDI:000473). *Pierre Le Merre*.
+- Presenting the IBL brain wide map dataset (DANDI:000409). *Mayo Faulkner*.
+- GLO: A dataset for investigating detection global and local oddballs in mouse visual cortex (DANDI:000253). *Jacob Westerberg*.
+
 ## Related Events
 
 The Neurodata and Tools Showcase is also part of a multi-day NWB Data Conversion workshop. If you are interested in attending these additional sessions to learn more about converting your own data to NWB and publishing on DANDI, please see the [Data Conversion Workshop page](https://neurodatawithoutborders.github.io/nwb_hackathons/HCK22_2025_DataConversion_Remote/) for more details.


### PR DESCRIPTION
Add agenda to data conversion workshop and list of presenters to neurodata and tools showcase.

Also add code of conduct page to link to from event files.