### PR TITLE
Add atproto-did for bluesky handle verification

### DIFF
--- a/static/.well-known/atproto-did
+++ b/static/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:dxo5vr7rpfietd6uamz3opx3


### PR DESCRIPTION
> The DID value is public and not sensitive information.

https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial