### PR TITLE
add link to data conversion and open Neurodata and tools showcase workshop report

### DIFF
--- a/content/events/hck22-2025-dataconversion-remote.md
+++ b/content/events/hck22-2025-dataconversion-remote.md
@@ -37,6 +37,10 @@ your data, including NWB GUIDE, a new no-code user interface for data conversion
 **Note:** All levels of experience are welcome! We will have tutorials ranging from no-code, automated data conversion to
 more advanced, custom code conversion.
 
+## Report
+
+The combined report for the NWB Data Conversion Workshop 2025 and the Open Neurodata and Tools Showcase 2025 is available online at [[PDF](https://drive.google.com/file/d/13S7hgWwk2QgcwMpNh-VeFU0JJcN2lxKa/view?usp=sharing)].
+
 ## Logistics
 
 We will be using Gather and Zoom for the meeting and will send an email in the days before the workshop with links.

--- a/content/events/hck23-2025-openneurodata-showcase.md
+++ b/content/events/hck23-2025-openneurodata-showcase.md
@@ -34,6 +34,10 @@ aliases:
 
 The Open Neurodata and Tools Showcase is a free virtual event in Gather where attendees can meet data contributors and tool developers, explore publicly available neurophysiology datasets in DANDI, and discover open-source tools integrated with the NWB ecosystem. This event provides an opportunity to connect with both dataset creators and tool developers to discuss their work, including open research questions and potential applications.
 
+## Report
+
+The combined report for the NWB Data Conversion Workshop 2025 and the Open Neurodata and Tools Showcase 2025 is available online at [[PDF](https://drive.google.com/file/d/13S7hgWwk2QgcwMpNh-VeFU0JJcN2lxKa/view?usp=sharing)].
+
 ## Target Audience
 
 This virtual event is open to anyone interested in neurophysiology data and tools, including but not limited to:


### PR DESCRIPTION
Adds a link to the workshop report stored on google drive. 

@oruebel and @alessandratrapani let me know if you have any feedback on the report content and I can update / share the overleaf