### PR TITLE
 Fix hero overlay blocking link clicks on “Converting Data to NWB”

### DIFF
--- a/static/css/list-alignment-fix.css
+++ b/static/css/list-alignment-fix.css
@@ -19,3 +19,13 @@
   padding-left: 0.5rem;
   margin-bottom: 0.75rem;
 }
+
+/* Prevent decorative hero ellipses from blocking clicks/selecting content */
+section.hero {
+  overflow: hidden;
+}
+
+.hero .ellipses,
+.hero .eventsEllipses {
+  pointer-events: none;
+}


### PR DESCRIPTION
Fix #129

The decorative hero “ellipses” overlapped the next section and intercepted clicks. To make the link clickable this PR updates the layout in `list-alignment-fix.css]` to add `section.hero { overflow: hidden; }` and `.hero .ellipses, .hero .eventsEllipses { pointer-events: none; }.` to make sure the ellipses is not stealing the clicks
