### PR TITLE
Close applications for NeuroDataReHack 2026

### DIFF
--- a/content/events/hck26-2026-janelia-ndrh.md
+++ b/content/events/hck26-2026-janelia-ndrh.md
@@ -45,15 +45,9 @@ We will also receive instructions from the [SPARC team](https://sparc.science/) 
 
 ## Application
 
-**Applications are now open!**
+**Applications are now closed.**
 
-Apply to participate in NeuroDataReHack 2026 by completing the application form:
-
-**[Apply Here](https://forms.gle/6uird2uknZeJbmPr7)**
-
-Space is limited, so we encourage you to apply early. Applications will be reviewed on a rolling basis.
-
-Applications close February 20, 2026.
+Thank you for your interest in NeuroDataReHack 2026. Applicants will be notified of decisions soon.
 
 ## Schedule
 


### PR DESCRIPTION
## Summary
- Close the application section for NeuroDataReHack 2026, replacing the open application form link with a notice that applications are closed and applicants will be notified soon.

## Test plan
- [x] Verify the event page renders correctly at `/events/hck26-2026-janelia-ndrh/`
- [x] Confirm application link is no longer visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)