### PR TITLE
Replace Mayo Faulkner with Pranav Rai for NeuroDataReHack 2026

### DIFF
--- a/content/events/hck26-2026-janelia-ndrh.md
+++ b/content/events/hck26-2026-janelia-ndrh.md
@@ -75,7 +75,7 @@ The event will feature a distinguished team of instructors, including:
 - **Misha Ahrens, Ph.D.** - Group Leader, HHMI Janelia Research Campus
 - **Jeremy Magland, Ph.D.** - Senior Data Scientist, Flatiron Institute (Lead developer of Neurosift, FigURL, Dendro)
 - **Guillaume Viejo, Ph.D.** - Data Scientist, Flatiron Institute (Lead developer of Pynapple)
-- **Mayo Faulkner, Ph.D.** - Senior Software Engineer, International Brain Lab
+- **Pranav Rai** - Software Engineer, International Brain Lab
 - **Carter Peene** - Data Analyst, Allen Institute for Neural Dynamics (Lead developer of OpenScope Databook)
 - **Vinam Arora** - Ph.D. candidate in Computer Science, University of Pennsylvania (Developer of torch_brain)
 - **Carsen Stringer, Ph.D.** - Group Leader, HHMI Janelia Research Campus (Lead developer of Rastermap, Suite2p, Facemap, Cellpose)


### PR DESCRIPTION
## Summary
- Swap out Mayo Faulkner (Senior Software Engineer, IBL) for Pranav Rai (Software Engineer, IBL) in the NeuroDataReHack 2026 instructor list.

## Test plan
- [x] Verify the instructor list renders correctly at `/events/hck26-2026-janelia-ndrh/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)