### PR TITLE
Add site-wide search to navbar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1083,42 +1083,73 @@ ol.custom-ordered-list li::before {
   padding: 0 10px !important;
 }
 
-/* Site-wide search bar in navbar */
-.site-search {
+/* Site-wide search: icon toggle + dropdown panel */
+.site-search-wrapper {
   position: relative;
-  width: 100%;
-  max-width: 240px;
 }
-.site-search .pagefind-ui__search-input {
-  height: 38px;
-  font-size: 14px;
-  padding: 6px 12px;
+.site-search-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50% !important;
+  cursor: pointer;
+}
+.site-search-toggle:hover,
+.site-search-toggle[aria-expanded="true"] {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+}
+.site-search-toggle .bi-search {
+  font-size: 1.2rem;
+  line-height: 1;
+  color: #ffffff !important;
+}
+.site-search-toggle:hover .bi-search,
+.site-search-toggle[aria-expanded="true"] .bi-search {
+  color: #ffffff !important;
+}
+.site-search-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(420px, 92vw);
+  background: #fff;
+  border: 1px solid #ebebeb;
   border-radius: 0.5rem;
-  border: 1px solid #d0d4dd;
-  background-color: #fff;
-  width: 100%;
-}
-.site-search .pagefind-ui__search-clear {
-  font-size: 13px;
-}
-.site-search .pagefind-ui__drawer {
-  position: absolute !important;
-  top: 44px !important;
-  right: 0 !important;
-  left: auto !important;
-  width: min(420px, 90vw) !important;
-  max-height: 70vh;
-  overflow-y: auto;
+  box-shadow: 0 8px 24px rgba(33, 37, 41, 0.12);
+  padding: 12px;
   z-index: 1050;
 }
+.site-search-panel[hidden] {
+  display: none;
+}
+.site-search-panel .pagefind-ui__search-input {
+  width: 100%;
+  height: 40px;
+  font-size: 14px;
+  padding: 8px 12px;
+  border: 1px solid #d0d4dd;
+  border-radius: 0.5rem;
+}
+.site-search-panel .pagefind-ui__drawer {
+  position: static !important;
+  top: auto !important;
+  right: auto !important;
+  left: auto !important;
+  width: 100% !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin-top: 8px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
 @media (max-width: 991.98px) {
-  .site-search {
-    max-width: 100%;
-  }
-  .site-search .pagefind-ui__drawer {
-    position: static !important;
-    width: 100% !important;
-    max-height: none;
+  .site-search-panel {
+    right: auto;
+    left: 0;
+    width: 100%;
   }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1083,6 +1083,45 @@ ol.custom-ordered-list li::before {
   padding: 0 10px !important;
 }
 
+/* Site-wide search bar in navbar */
+.site-search {
+  position: relative;
+  width: 100%;
+  max-width: 240px;
+}
+.site-search .pagefind-ui__search-input {
+  height: 38px;
+  font-size: 14px;
+  padding: 6px 12px;
+  border-radius: 0.5rem;
+  border: 1px solid #d0d4dd;
+  background-color: #fff;
+  width: 100%;
+}
+.site-search .pagefind-ui__search-clear {
+  font-size: 13px;
+}
+.site-search .pagefind-ui__drawer {
+  position: absolute !important;
+  top: 44px !important;
+  right: 0 !important;
+  left: auto !important;
+  width: min(420px, 90vw) !important;
+  max-height: 70vh;
+  overflow-y: auto;
+  z-index: 1050;
+}
+@media (max-width: 991.98px) {
+  .site-search {
+    max-width: 100%;
+  }
+  .site-search .pagefind-ui__drawer {
+    position: static !important;
+    width: 100% !important;
+    max-height: none;
+  }
+}
+
 /* Contact Us */
 .contactP a {
   color: #171b26 !important;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -119,6 +119,34 @@ document.addEventListener("DOMContentLoaded", function () {
         resetStyles: false,
       });
     }
+
+    // Site-search toggle
+    const searchToggle = document.querySelector(".site-search-toggle");
+    const searchPanel = document.querySelector(".site-search-panel");
+    if (searchToggle && searchPanel) {
+      const closePanel = () => {
+        searchPanel.hidden = true;
+        searchToggle.setAttribute("aria-expanded", "false");
+      };
+      const openPanel = () => {
+        searchPanel.hidden = false;
+        searchToggle.setAttribute("aria-expanded", "true");
+        const input = searchPanel.querySelector(".pagefind-ui__search-input");
+        if (input) input.focus();
+      };
+      searchToggle.addEventListener("click", (e) => {
+        e.stopPropagation();
+        searchPanel.hidden ? openPanel() : closePanel();
+      });
+      document.addEventListener("click", (e) => {
+        if (!searchPanel.hidden && !searchPanel.contains(e.target) && e.target !== searchToggle) {
+          closePanel();
+        }
+      });
+      document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && !searchPanel.hidden) closePanel();
+      });
+    }
   });
 
   if (logos) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -108,7 +108,17 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // PageFind Init
   window.addEventListener('DOMContentLoaded', (event) => {
-    new PagefindUI({ element: "#search", showSubResults: true });
+    if (document.getElementById("search")) {
+      new PagefindUI({ element: "#search", showSubResults: true });
+    }
+    if (document.getElementById("site-search")) {
+      new PagefindUI({
+        element: "#site-search",
+        showSubResults: true,
+        showImages: false,
+        resetStyles: false,
+      });
+    }
   });
 
   if (logos) {

--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -37,7 +37,7 @@
         </div>
         <div class="row justify-content-between g-5">
             <div class="col-lg-8">
-                <div class="row g-4" data-pagefind-body>
+                <div class="row g-4">
                     {{ $pages := where site.RegularPages "Section" "news" }}
                     {{ $paginator := .Paginate $pages.ByWeight }}
                     {{ range $paginator.Pages }}

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -131,7 +131,7 @@
 
             <div class="col-lg-4 mt-5 ps-lg-5">
                 <h4 class="inter-600 text-24 dark-900">Recent News</h4>
-                <div class="row g-2" data-pagefind-body>
+                <div class="row g-2">
                     {{ $pages := where .Site.RegularPages "Section" "news" }}
                     {{ range first 4 ($pages.ByDate.Reverse) }}
                     <div class="col-md-6 col-lg-12 col-sm-8 mx-auto">

--- a/layouts/partials/shared/header.html
+++ b/layouts/partials/shared/header.html
@@ -134,8 +134,10 @@
               {{ end }}
             </ul>
 
+            <div id="site-search" class="site-search ms-lg-3 my-2 my-lg-0"></div>
+
             {{ if $navButton }}
-              <div class="navbar-right">
+              <div class="navbar-right ms-lg-3">
                 <a
                   href="{{ site.Params.cta.link | relURL }}"
                   class="btn btn-primary bg-second scale border-second animate">

--- a/layouts/partials/shared/header.html
+++ b/layouts/partials/shared/header.html
@@ -3,7 +3,7 @@
 <header class="header-nav py-3 header">
   <div class="container-lg">
     <div class="row">
-      <div class="col-12 px-0">
+      <div class="col-12 px-3 px-lg-0">
         <nav class="navbar navbar-expand-lg p-0">
           <a class="navbar-brand" href="{{ site.BaseURL | relLangURL }}">
             <img src="{{ site.Params.logo }}" alt="" class="img-fluid" width="200px">
@@ -134,7 +134,18 @@
               {{ end }}
             </ul>
 
-            <div id="site-search" class="site-search ms-lg-3 my-2 my-lg-0"></div>
+            <div class="site-search-wrapper ms-lg-2 my-2 my-lg-0">
+              <button
+                type="button"
+                class="site-search-toggle btn p-0 border-0 bg-transparent"
+                aria-label="Search the site"
+                aria-expanded="false">
+                <i class="bi bi-search dark-300"></i>
+              </button>
+              <div class="site-search-panel" hidden>
+                <div id="site-search"></div>
+              </div>
+            </div>
 
             {{ if $navButton }}
               <div class="navbar-right ms-lg-3">


### PR DESCRIPTION
## Summary
- Adds a magnifier icon in the navbar that opens a Pagefind-powered search dropdown (closes on outside click or Escape)
- Pagefind indexing was already wired into the Netlify build; this just exposes the UI
- Fixes a bug where only 12 pages were indexed: the news templates wrapped a sidebar widget in \`data-pagefind-body\`, which silently excluded every page that didn't have that attribute. Removing it brings the index up to ~143 pages, so queries like "lodging" now hit `/organizing-nwb-events/` etc.
- Small mobile-only horizontal padding fix on the navbar container so the logo isn't flush with the screen edge

## Test plan
- [ ] Click the magnifier icon in the navbar — search panel opens, input is auto-focused
- [ ] Type a query — relevant pages from across the site appear (try "lodging", "pynapple", "newsletter")
- [ ] Click outside the panel or press Escape — panel closes
- [ ] Resize to mobile width — logo no longer touches the left edge; search icon still accessible
- [ ] News listing and post pages still render correctly (sidebar widget unchanged in appearance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)