### PR TITLE
Fix lychee link check (informational + base URL resolution)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -22,5 +22,21 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # NOTE: Lychee (and sphinx) encounter issues with SSL certificates for INCF URLs, so use --insecure
-          args: --verbose --no-progress './content/**/*.md' './content/**/*.html' './content/**/*.rst' --insecure
+          # --base resolves root-relative paths (e.g. /events/) against the live site
+          # --accept includes 403/429 since many destinations (mathworks, hilton, doi.org,
+          #   slack invites) reject lychee's user-agent rather than the link being broken
+          # --insecure: lychee (and sphinx) hit SSL cert issues on INCF URLs
+          args: >-
+            --verbose
+            --no-progress
+            --base 'https://neurodatawithoutborders.github.io/'
+            --accept '200..=299,403,429'
+            --max-retries 2
+            --insecure
+            './content/**/*.md'
+            './content/**/*.html'
+            './content/**/*.rst'
+          # Don't block PRs on the report; the job summary still surfaces broken links
+          # so they can be triaged separately. Pre-existing dead links in archived
+          # event pages otherwise fail every PR.
+          fail: false


### PR DESCRIPTION
## Summary
The link-check workflow has been failing on every PR and on the weekly cron run on \`main\` (see e.g. [run 25570907599](https://github.com/NeurodataWithoutBorders/neurodatawithoutborders.github.io/actions/runs/25570907599/job/75066079214?pr=151)). Two problems:

1. **No \`--base\` configured** — lychee couldn't resolve root-relative URLs like \`/events/\`, \`/team\`, \`/supporting-nwb/\`, so it errored \"Cannot convert path to a URI\" for every internal link. The vast majority of reported errors were false negatives.
2. **Anti-bot 403s treated as failures** — mathworks, hilton, marriott, doi.org, slack invites, etc. reject lychee's user-agent rather than the link being broken.

There are also some genuine 404s in older archived event pages (e.g. \`alleninstitute.org/...2022-neurodatarehack-hackathon/\`, \`freehandhotels.com/summer-in-the-city/\`). Those need content cleanup, separate from this CI fix.

## Changes
- \`--base 'https://neurodatawithoutborders.github.io/'\` so root-relative paths resolve against the live site
- \`--accept '200..=299,403,429'\` so anti-bot/throttle responses pass
- \`--max-retries 2\` for transient flakes
- \`fail: false\` — keep the job-summary report (already configured), but stop blocking PRs on pre-existing dead links. Broken links can be triaged from the summary.

## Test plan
- [ ] Verify the workflow runs on this PR and surfaces the report in the job summary
- [ ] Verify the run no longer fails the PR check
- [ ] Spot-check that root-relative URLs (\`/events/\`, \`/team\`) are now resolved correctly in the report
- [ ] Confirm \`https://www.mathworks.com/\` and similar 403s no longer appear as failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)