### PR TITLE
Remove placeholder Archives section from news layouts

### DIFF
--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -147,24 +147,6 @@
                     {{ end }}
                 </div>
 
-                <h4 class="inter-600 text-24 dark-900 mt-5">Archives</h4>
-                <div class="row g-2">
-                    <div class="col-sm-6 col-lg-12">
-                        <div class="rounded-3 bg-white shadow-sm p-3">
-                            <div class="d-flex align-items-start gap-3">
-                                <div>
-                                    <img src="/images/essentials/bookmark_star.png" alt="" width="15">
-                                </div>
-                                <div>
-                                    <h4 class="inter-600 text-14 dark-900 mb-1 mt-1">August 2022</h4>
-                                    <p class="inter-400 text-12 dark-700 mb-0">Nunc vulputate libero et velit interdum,
-                                        ac aliquet.</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
             </div>
         </div>
     </div>

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -169,24 +169,6 @@
                     {{ end }}
                 </div>
 
-                <h4 class="inter-600 text-24 dark-900 mt-5">Archives</h4>
-                <div class="row g-2">
-                    <div class="col-sm-6 col-lg-12">
-                        <div class="rounded-3 bg-white shadow-sm p-3">
-                            <div class="d-flex align-items-start gap-3">
-                                <div>
-                                    <img src="/images/essentials/bookmark_star.png" alt="" width="15">
-                                </div>
-                                <div>
-                                    <h4 class="inter-600 text-14 dark-900 mb-1 mt-1">August 2022</h4>
-                                    <p class="inter-400 text-12 dark-700 mb-0">Nunc vulputate libero et velit interdum,
-                                        ac aliquet.</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

Removes the placeholder **Archives** subsection from the news/blog sidebars. It contained a hardcoded "August 2022" card with lorem ipsum text ("Nunc vulputate libero et velit interdum, ac aliquet.") that was never wired up to real content.

## Changes

- `layouts/news/list.html` — removed the Archives block from the blog list sidebar
- `layouts/news/single.html` — removed the Archives block from the single-post sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)