### PR TITLE
Fix bad HTML comment and update instructor list on NDRH 2026 page

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -3,8 +3,8 @@
   "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2@v2.21100.20000/package/dist/cjs/*",
-    "../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/twbs/bootstrap@v5.3.2+incompatible/js/*"
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2@v2.21100.20000/package/dist/cjs/*",
+    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/twbs/bootstrap@v5.3.2+incompatible/js/*"
    ]
   }
  }

--- a/content/events/hck26-2026-janelia-ndrh.md
+++ b/content/events/hck26-2026-janelia-ndrh.md
@@ -83,7 +83,7 @@ The event will feature a distinguished team of instructors, including:
 
 - **Alessio Buccino, Ph.D.** - Electrophysiology Pipeline Engineer, Allen Institute for Neural Dynamics (Lead developer of SpikeInterface)
 
-- 
+-->
 
 Additional instructors to be announced.
 

--- a/content/events/hck26-2026-janelia-ndrh.md
+++ b/content/events/hck26-2026-janelia-ndrh.md
@@ -70,20 +70,20 @@ The event will feature a distinguished team of instructors, including:
 - **Benjamin Dichter, Ph.D.** - Program Chair, CatalystNeuro
 - **Ryan Ly, Ph.D.** - Lawrence Berkeley National Laboratory
 - **Oliver Rübel, Ph.D.** - Lawrence Berkeley National Laboratory
-- **Misha Ahrens, Ph.D.** - Group Leader, HHMI Janelia Research Campus
-- **Jeremy Magland, Ph.D.** - Senior Data Scientist, Flatiron Institute (Lead developer of Neurosift, FigURL, Dendro)
-- **Guillaume Viejo, Ph.D.** - Data Scientist, Flatiron Institute (Lead developer of Pynapple)
 - **Pranav Rai** - Software Engineer, International Brain Lab
+- **Jérôme Lecoq, Ph.D.** - Associate Investigator, Allen Institute for Neural Dynamics (Lead of OpenScope)
 - **Carter Peene** - Data Analyst, Allen Institute for Neural Dynamics (Lead developer of OpenScope Databook)
-- **Vinam Arora** - Ph.D. candidate in Computer Science, University of Pennsylvania (Developer of torch_brain)
-- **Carsen Stringer, Ph.D.** - Group Leader, HHMI Janelia Research Campus (Lead developer of Rastermap, Suite2p, Facemap, Cellpose)
+- **Will Slatton** - Ph.D. student, Harvard University
+- **Guillaume Viejo, Ph.D.** - Data Scientist, Flatiron Institute (Lead developer of Pynapple)
+- **Misha Ahrens, Ph.D.** - Group Leader, HHMI Janelia Research Campus
+- **Alexandre André** - Ph.D. student, University of Pennsylvania (Developer of torch_brain)
+- **Robin Dard, Ph.D.** - Postdoctoral Researcher, École Polytechnique Fédérale de Lausanne
+- **Jeremy Magland, Ph.D.** - Senior Data Scientist, Flatiron Institute (Lead developer of Neurosift, FigURL, Dendro)
 - **Jakob Voigts, Ph.D.** - Group Leader, HHMI Janelia Research Campus
-
-<!-- 
-
+- **Carsen Stringer, Ph.D.** - Group Leader, HHMI Janelia Research Campus (Lead developer of Rastermap, Suite2p, Facemap, Cellpose)
+- **Atika Syeda** - Ph.D. student, HHMI Janelia Research Campus (Lead developer of Facemap)
+- **Jacob Pennington** - Software Developer, HHMI Janelia Research Campus (Developer of Kilosort4)
 - **Alessio Buccino, Ph.D.** - Electrophysiology Pipeline Engineer, Allen Institute for Neural Dynamics (Lead developer of SpikeInterface)
-
--->
 
 Additional instructors to be announced.
 

--- a/content/events/hck26-2026-janelia-ndrh.md
+++ b/content/events/hck26-2026-janelia-ndrh.md
@@ -85,8 +85,6 @@ The event will feature a distinguished team of instructors, including:
 - **Jacob Pennington** - Software Developer, HHMI Janelia Research Campus (Developer of Kilosort4)
 - **Alessio Buccino, Ph.D.** - Electrophysiology Pipeline Engineer, Allen Institute for Neural Dynamics (Lead developer of SpikeInterface)
 
-Additional instructors to be announced.
-
 ## Eligibility
 
 Eligibility is broad. This course is intended for PhD students, postdoctoral researchers, principal investigators, or similar.


### PR DESCRIPTION
Due to an HTML comment without proper closure, the main menu on the NDRH 2026 page is rendering without background when scrolling.

**Current**

<img width="1374" height="142" alt="Screenshot 2026-07-12 at 11 31 45 AM" src="https://github.com/user-attachments/assets/9fbac330-0b49-4a95-8fc1-218d163abaa8" />

**With fix**

<img width="1264" height="156" alt="Screenshot 2026-07-12 at 11 33 13 AM" src="https://github.com/user-attachments/assets/8ce89f50-dc53-4a52-ad7a-56ad9ac5f7f0" />
