### PR TITLE
Announce NeuroDataReHack 2027

### DIFF
--- a/content/events/hck27-2027-janelia-ndrh.md
+++ b/content/events/hck27-2027-janelia-ndrh.md
@@ -22,7 +22,7 @@ NeuroDataReHack 2027 will be held at the HHMI Janelia Research Campus in Ashburn
 
 ## Objective
 
-[The DANDI Archive](http://dandiarchive.org) now has 450+ neurophysiology datasets in the 
+[The DANDI Archive](http://dandiarchive.org) now has 550+ neurophysiology datasets in the 
 [Neurodata Without Borders](http://nwb.org) format spanning many species, brain areas, task types, and imaging 
 modalities. These include high-value datasets, e.g. from [Allen Institute OpenScope](https://dandiarchive.org/dandiset/search?search=openscope), the [MICrONS project](https://dandiarchive.org/dandiset/000402), and the 
 [International Brain Laboratory Brain Wide Map](https://dandiarchive.org/dandiset/000409), as well as diverse contributions from neuroscience labs around the world. In this 

--- a/content/events/hck27-2027-janelia-ndrh.md
+++ b/content/events/hck27-2027-janelia-ndrh.md
@@ -1,0 +1,87 @@
+---
+title: "NeuroDataReHack 2027"
+date: 2027-07-18
+endDate: 2027-07-24
+location: "HHMI Janelia Research Campus, Ashburn, VA"
+eventType: "Hackathon"
+weight: 20270718
+summary: "Unlock new discoveries in neurophysiology through secondary analysis."
+draft: false
+organizers:
+  - "Benjamin Dichter, Ph.D. (Program Chair)"
+resources:
+  "PyNWB Documentation": "https://pynwb.readthedocs.io/en/stable/install_users.html#installing-pynwb"
+  "MatNWB Documentation": "https://matnwb.readthedocs.io"
+aliases:
+  - /nwb_hackathons/HCK27_2027_Janelia_NDRH
+---
+
+## Dates and Location
+
+NeuroDataReHack 2027 will be held at the HHMI Janelia Research Campus in Ashburn, Virginia. Participants arrive the evening of Sunday, July 18, 2027. The program runs from Monday, July 19 through Saturday, July 24, and participants have the option to check out on Sunday, July 25.
+
+## Objective
+
+[The DANDI Archive](http://dandiarchive.org) now has 450+ neurophysiology datasets in the 
+[Neurodata Without Borders](http://nwb.org) format spanning many species, brain areas, task types, and imaging 
+modalities. These include high-value datasets, e.g. from [Allen Institute OpenScope](https://dandiarchive.org/dandiset/search?search=openscope), the [MICrONS project](https://dandiarchive.org/dandiset/000402), and the 
+[International Brain Laboratory Brain Wide Map](https://dandiarchive.org/dandiset/000409), as well as diverse contributions from neuroscience labs around the world. In this 
+workshop, we will teach attendees about the open neurophysiology datasets available on the DANDI Archive and train 
+them on how to maximally utilize the archive and the NWB standard to incorporate existing data into their scientific 
+workflows. Feedback from attendees will be used to improve the software and data standard to better enable 
+reanalysis workflows.
+
+Example projects include but are not limited to:
+* Determine whether your result is present in another species or brain area.
+* Showcase the capabilities of your tool or analysis on existing data from another lab.
+* Explore follow-up questions to a study.
+* Create educational content that uses open data.
+
+This event will primarily focus on analyzing existing data in NWB and on DANDI, **not** converting data to NWB. If 
+you are interested in learning how to convert data, consider signing up for an NWB Data Conversion Workshop.
+
+## Application
+
+Applications are not yet open. They will open in the coming months, and the application form and full details will be posted here. To be notified when applications open, subscribe to the [NWB mailing list](https://mailchi.mp/fe2a9bc55a1a/nwb-signup).
+
+## Schedule
+
+A detailed schedule will be posted closer to the event. For a sense of the format, see the recordings and schedule from the [2026 NeuroDataReHack](/events/hck26-2026-janelia-ndrh/).
+
+## Instructors
+
+Instructors will be announced closer to the event.
+
+## Eligibility
+
+Eligibility is broad. This course is intended for PhD students, postdoctoral researchers, principal investigators, or similar.
+Advanced undergraduates may be considered on a case-by-case basis. We welcome applicants from all areas of
+neuroscience, including but not limited to experimentalists, computational neuroscientists, and data scientists.
+Applicants should have basic programming experience in Python or MATLAB and experience with neurophysiology research.
+Preference will be given to applicants who have a specific project in mind that involves reanalyzing existing
+neurophysiology data in NWB format and who has not previously attended a NeuroDataReHack event.
+
+## Logistics
+
+Thanks to the generous sponsorship of The Janelia Research Campus, this event will be free to participants:
+* There is no registration or application fee.
+* Participants will be provided a private room at Janelia Research Campus for the duration of this event, 
+  checking in the evening of Sunday, July 18 and checking out on Saturday, July 24 or the morning of Sunday, July 25.
+* Breakfast, lunch, dinner, and coffee breaks will be provided. Janelia is adept at accommodating dietary 
+  restrictions; please indicate any dietary restrictions on your application.
+* You will be responsible for booking your own flight and transportation to Janelia Research Campus.
+* You will be responsible for determining visa and/or healthcare requirements for travel to the United States. Please 
+  plan accordingly, as this process can take several months. We would be happy to provide a letter of invitation to
+  support your visa application if needed.
+
+## What to Bring
+
+Bring a laptop with appropriate software installed. Python should be installed and MATLAB is optional. For 
+instructions on how to install PyNWB, see 
+[the PyNWB documentation](https://pynwb.readthedocs.io/en/stable/install_users.html#installing-pynwb). For instructions
+on how to install MatNWB, see
+[the MatNWB documentation](https://matnwb.readthedocs.io)
+
+## Code of Conduct
+
+Please see the [Code of Conduct](https://neurodatawithoutborders.github.io/nwb_hackathons/code_of_conduct) for all NWB events.


### PR DESCRIPTION
Adds an event page announcing NeuroDataReHack 2027 at the HHMI Janelia Research Campus.

## Details
- **Location:** HHMI Janelia Research Campus, Ashburn, VA
- **Arrival:** evening of Sunday, July 18, 2027
- **Program:** Monday, July 19 through Saturday, July 24
- **Departure:** option to check out Sunday, July 25

The page follows the structure of the 2026 event page. Because the event is still far off, the Application, Schedule, and Instructors sections are placeholders noting that details are forthcoming, and the Application section points to the mailing list for notification when applications open.

## Notes
- No banner image is set yet, so the page renders without one (the single-event template guards the image field). A 2027 banner can be added under `static/images/events/hck27-2027-janelia-ndrh/` and referenced from the front matter when it is ready.
- The page appears under "Upcoming Events" on the events list once the date is in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)