### PR TITLE
Open NeuroDataReHack 2027 applications

### DIFF
--- a/content/events/hck27-2027-janelia-ndrh.md
+++ b/content/events/hck27-2027-janelia-ndrh.md
@@ -42,7 +42,13 @@ you are interested in learning how to convert data, consider signing up for an N
 
 ## Application
 
-Applications are not yet open. They will open in the coming months, and the application form and full details will be posted here. To be notified when applications open, subscribe to the [NWB mailing list](https://mailchi.mp/fe2a9bc55a1a/nwb-signup).
+**Applications are now open!**
+
+Apply to participate in NeuroDataReHack 2027 by completing the application form:
+
+**[Apply Here](https://forms.gle/sYN6iTLZ7QXYDqXw8)**
+
+Space is limited and applications are reviewed on a rolling basis, so we encourage you to apply early. Applications close Friday, January 29, 2027.
 
 ## Schedule
 


### PR DESCRIPTION
Add the application form link to the event page and mark applications as open, with a closing date of Friday, January 29, 2027.


Claude-Session: https://claude.ai/code/session_01VhJgo7TdFYpPiuBehNr9im