### PR TITLE
Link the NeuroDataReHack 2026 report

### DIFF
--- a/content/events/hck26-2026-janelia-ndrh.md
+++ b/content/events/hck26-2026-janelia-ndrh.md
@@ -13,6 +13,7 @@ organizers:
 #   - "Stephanie Prince, Ph.D. (Program Chair)"
 #   - "Ryan Ly, Ph.D. (Program Chair)"
 resources:
+  "Event Report": "https://drive.google.com/file/d/1CIcdLK5kTdYPIuCoGcqTIxnliTI6Yso3/view?usp=sharing"
   "Recorded Talks": "https://www.youtube.com/playlist?list=PLEv3d3vCiZ20"
 #   "Event Flyer": "https://drive.google.com/file/d/1ptsGRa1sEMh-je7L_ff3CgtRTj-X11lO/view?usp=sharing"
 #   "Slides from the 2025 NeuroDataReHack": "https://drive.google.com/drive/folders/1DAmQr4qWCamhj_2Zyke0kkHGvV8Kyq13?usp=sharing"
@@ -21,6 +22,10 @@ resources:
 aliases:
   - /nwb_hackathons/HCK26_2026_Janelia_NDRH
 ---
+
+## Report
+
+See the [NeuroDataReHack 2026 Report](https://drive.google.com/file/d/1CIcdLK5kTdYPIuCoGcqTIxnliTI6Yso3/view?usp=sharing) for a summary of the event, projects completed, and feedback from participants.
 
 ## Objective
 


### PR DESCRIPTION
Adds a link to the official NeuroDataReHack 2026 report on the event page. The report appears in two places, matching how the 2025 event page presents it: a `Report` section at the top of the page body, and an `Event Report` entry in the resources sidebar.

Report: https://drive.google.com/file/d/1CIcdLK5kTdYPIuCoGcqTIxnliTI6Yso3/view?usp=sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)